### PR TITLE
Post notification slack api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem 'sassc', '2.1.0'
 
 gem 'enum_help'
 gem 'bootstrap'
+gem 'slack-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,7 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
+    slack-notifier (2.3.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -294,6 +295,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sassc (= 2.1.0)
   selenium-webdriver
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -47,9 +47,9 @@ class ArticlesController < ApplicationController
   def set_article
     @article = Article.find(params[:id])
   end
-
+  
   def post_notification(article)
-    notification = Slack::Notifier.new "https://hooks.slack.com/services/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"
+    notification = Slack::Notifier.new "https://hooks.slack.com/services/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"
       message = {
                   "fallback": "Tech::Shareに新しい記事が投稿されました。",
                   "color": "#8888",

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,7 +15,8 @@ class ArticlesController < ApplicationController
 
   def create
     article = Article.new(article_params)
-    if article.save!
+    if article.save
+      post_notification(article)
       redirect_to articles_path
     else
       render :new
@@ -45,6 +46,23 @@ class ArticlesController < ApplicationController
 
   def set_article
     @article = Article.find(params[:id])
+  end
+
+  def post_notification(article)
+    notification = Slack::Notifier.new "https://hooks.slack.com/services/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"
+      message = {
+                  "fallback": "Tech::Shareに新しい記事が投稿されました。",
+                  "color": "#8888",
+                  "pretext": "<!here> Tech::Shareに新しい記事が投稿されました。",
+                  "author_name": "user_name",
+                  "author_link": "user_mypage_url",
+                  "author_icon": "https://icon-pit.com/wp-content/uploads/2018/10/person_icon_364-300x300.png",
+                  "title": "#{article.title}\nhttp://localhost:3000/articles/#{article.id}",
+                  "title_link": "http://localhost:3000/articles/#{article.id}",
+                  "text": "#{article.content}",
+                  "image_url": "https://i0.wp.com/pg-work.com/wp-content/uploads/2019/08/TECHEXPERT-e1533109650694.png?resize=727%2C222&ssl=1"
+        }
+      notification.post attachments: [message]
   end
 
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -49,7 +49,7 @@ class ArticlesController < ApplicationController
   end
   
   def post_notification(article)
-    notification = Slack::Notifier.new "https://hooks.slack.com/services/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"
+    notification = Slack::Notifier.new "https://hooks.slack.com/services/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"
       message = {
                   "fallback": "Tech::Shareに新しい記事が投稿されました。",
                   "color": "#8888",


### PR DESCRIPTION
![slack_api](https://user-images.githubusercontent.com/51068074/72515008-8f5f7580-3892-11ea-9d15-6b165414e2e1.gif)

# What
- なにをどう変更したか
- gem slack-notifierをインストールして
- 通知を送りたいチャンネルにIncoming Webhookを追加する。
- articles_controller.rbにWebhook URLを記述してどのチャンネルに送るかを定義する。
- どういった形式の通知を送りたいかを定義する。

# Why
- なぜこの変更をするのか
- 新しい記事が投稿された時に通知としてslackにも投稿することによって、誰がどんな記事を投稿したかを確認でき。
- 通知がこない場合、投稿しても誰も傷かづそのままサービス自体忘れさられる可能性を防ぐ
- ユーザーは記事を投稿すれば通知がくるので好きな記事を投稿すれば良い。

# (WIP) 
## 作業中
- 現在の進捗

## 意見求む

- 記事を投稿した時だけだはなく編集をした時にも通知が欲しいかどうか。
- その他通知が欲しい機能はあるか？
- 仮説
- 検証

## WIPが外れる条件
- いつ
- どういう結果が得られたら

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
- その他コードへの影響

# 関連URL
- 参考URL
- 画像URL

# 大きな仕様変更
- before
- after

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- divのワークスペースのチャンネル#slack_api_test_channelに参加する。
- 好きな記事を投稿する。

- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
- 保留項目

# その他
