### PR TITLE
[WIP]Add image upload function

### DIFF
--- a/app/assets/javascripts/image_upload.js
+++ b/app/assets/javascripts/image_upload.js
@@ -1,0 +1,38 @@
+$(function () {
+
+$("#article_image").on('change', function(e) {
+
+  // file_filedのバリューを取得（そもそもここが違う？ActiveStrageだとどういった形でinputに入るのか？）
+  image = $(this).val();
+  console.log(image)
+
+  $.ajax({
+    url: "/articles",
+    type: "POST",
+    data: {image: image},
+    dataType: 'json',
+    beforeSend: function(xhr) {
+      xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'));
+      // CSRFのエラーがでたのでトークン組み込み
+    }
+  })
+  .done(function(image){
+
+  })
+  .fail(function(){
+      alert('メッセージを入力してください')
+  })
+
+    // const file = e.target.files[0];
+  //   // ファイル選択画面で選択された情報を取得
+  // const blobUrl = window.URL.createObjectURL(file);
+  //   // ブラウザ上からfileデータを取得
+
+  // console.log(blobUrl);
+
+  // formData = new FormData(document.querySelector("form"))
+
+  // console.log(formData)
+
+});
+});

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -17,6 +17,9 @@ class ArticlesController < ApplicationController
   end
 
   def create
+    # ここに画像のアップトードをするのか
+    # imageだけDBに保存するアクションを作った方が良いのか
+    # その場合に記事との関連はどうするのか
     article = current_user.articles.new(article_params)
     if article.save
       begin

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,4 +5,5 @@ class Article < ApplicationRecord
   has_many :tags, through: :article_tags
   belongs_to :user
   has_many :favorites, dependent: :destroy
+  has_one_attached :image
 end

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -10,3 +10,4 @@
       = f.label "内容", for: "examplecontent"
       = f.text_area :content, id: "examplecontent", class: "form-control",placeholder: "```コードブロックが使えます```", rows: "14"
     = f.submit "ナレッジを投稿する", class: "btn btn-outline-dark btn-block mt-2"
+    = f.file_field :image

--- a/db/migrate/20200405070745_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200405070745_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_095025) do
+ActiveRecord::Schema.define(version: 2020_04_05_070745) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "answer_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "content", null: false
@@ -115,6 +136,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_095025) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "answer_comments", "answers"
   add_foreign_key "answer_comments", "users"
   add_foreign_key "answers", "questions"


### PR DESCRIPTION
# What
- 記事を作成する際に画像をアップロードできるようにする

# Why
- ナレッジの紹介時に画像が添付されていた方が内容がより伝わりやすくなるため

# (WIP) 
## 作業中
①ActiveStrageの導入
②画像選択ボタンを表示（まず画像1枚）←ここまで完了
③ファイルが選択されたらAjaxで非同期で画像をローカルに保存。←ここで詰まっております！

## 意見求む
- 解決したい課題
1. 画像を保存する際に、記事の保存のcreateアクションとは別のアクションで切り分けた方が良いか？
2. 画像を先に保存しその後で記事の保存という流れになると思うが、画像だけ先に保存する場合に、f.file_filedのvalを取得して保存しようと思っているが、そもそも先に画像レコードがないのにどうやってattachするのか？ 先に画像を保存してしまっているので、記事が投稿された時にどう画像と紐づけるのか？

- 自力で調べた内容
・ActiveStrageはarticleテーブルにimageカラムをもつようなイメージ
・S3に投稿するが多くローカルで保存する記事がなかなか見つからず教えていただければと思います！

- 仮説
1. 画像だけ先に保存して記事内容などは空のレコードを作っておく
2. 記事が保存されたらその1.のレコードに記事内容などを挿入する？

# TODOと保留
- TODO
④doneで返ってきたデータをappendでURL表示
⑤記事が投稿されたら画像と紐づける？
⑥画像選択をドラッグ&ドロップに変更
⑦appendする際にマークダウン式に変更