### PR TITLE
Add ajax tag function

### DIFF
--- a/app/assets/javascripts/api/tags.js
+++ b/app/assets/javascripts/api/tags.js
@@ -11,27 +11,33 @@ $(document).on('turbolinks:load', function() {
 
   // タグ名とidを受け取り、タグ一覧へ追加する関数
   const appendTag = (name, id)=>{
+    // articleかquestionかをpathnameから作成する
+    const resourceName = location.pathname.slice(1).slice(0,-5)
     const html = `<button class="btn btn-sm btn-outline-secondary rounded-pill selected-tag js-selected_tag">
                     <i class="far fa-times-circle" aria-hidden="true"></i>
                     <span>${name}</span>
-                    <input multiple="multiple" value=${id} type="hidden" name="article[tag_ids][]" class="tag_ids">
+                    <input multiple="multiple" value=${id} type="hidden" name="${resourceName}[tag_ids][]" class="tag_ids">
                   </button>`
     $('.js-selected_tags').append(html)
+    $('.js-tag_name_field').val("")
   }
 
   // タグのインクリメンタルサーチ
   $('.js-tag_name_field').on('input', function(){
     const keyword = this.value;
+    let tag_ids = []
+    // 入力無しなら処理終了
     if (keyword === '') {
       $('.js-tag_list').empty()
       return
     }
-    let tag_ids = []
+    // すでに選択中のタグIDをtag_idsに入れてコントローラで検索から除く
     if($('.tag_ids')) {
       $('.tag_ids').each(function(_, ele){
         tag_ids.push(ele.value)
       })
     }
+    // api/tags#searchを叩く
     $.ajax({
       url: '/api/tags/search',
       type: 'GET',
@@ -43,40 +49,56 @@ $(document).on('turbolinks:load', function() {
     })
     .done(function(tags) {
       $('.js-tag_list').empty()
+      // liを大量に入れるための変数
       let tag_list_items = ''
       tags.forEach(tag => {
         tag_list_items += buildTag(tag)
       });
       $('.js-tag_list').append(tag_list_items)
     })
+    .fail(function(e){
+
+    })
   })
 
-  // 追加ボタン
+  // 選択中のタグへ追加
   $('.js-tag_list').on('click', '.js-add_tag_btn', function(e) {
     e.preventDefault()
     appendTag($(this).prev().text(), $(this).prev()[0].dataset.id)
     $(this).parent().remove()
   })
 
-  // 削除ボタン
+  // 選択中のタグから削除
   $('.js-selected_tags').on('click', '.js-selected_tag', function(e) {
     e.preventDefault()
     $(this).remove()
   })
 
-  // タグ作成ボタン
+  // タグを作成
   $('.js-create_tag').on('click', function(e) {
     e.preventDefault()
     const tagName = $('.js-tag_name_field').val()
+    if (tagName === '') {
+      alert('タグ名を入力して下さい')
+      return
+    }
+    // csrfトークンをmetaタグから取得する
+    const token = $('meta[name=csrf-token]').attr('content')
+    // api/tags#createを叩く
     $.ajax({
       url: '/api/tags',
       type: 'POST',
       data: {
-        tag_name: tagName
+        name: tagName,
+        authenticity_token: token // ここでcsrfトークンを送る
       },
       dataType: 'json'
     })
-    .done(function(tags) {
+    .done(function(tag) {
+      appendTag(tag.name, tag.id)
+    })
+    .fail(function(e) {
+
     })
   })
 })

--- a/app/assets/javascripts/api/tags.js
+++ b/app/assets/javascripts/api/tags.js
@@ -1,0 +1,82 @@
+$(document).on('turbolinks:load', function() {
+
+  // インクリメンタルサーチで追加されるhtml
+  const buildTag = (tag)=>{
+    const html = `<li class="list-group-item d-flex justify-content-between">
+                    <div class="tag_name" data-id=${tag.id}>${tag.name}</div>
+                    <button class="add_tag_btn btn-sm rounded-pill btn-success js-add_tag_btn">add</button>
+                  </li>`
+    return html
+  }
+
+  // タグ名とidを受け取り、タグ一覧へ追加する関数
+  const appendTag = (name, id)=>{
+    const html = `<button class="btn btn-sm btn-outline-secondary rounded-pill selected-tag js-selected_tag">
+                    <i class="far fa-times-circle" aria-hidden="true"></i>
+                    <span>${name}</span>
+                    <input multiple="multiple" value=${id} type="hidden" name="article[tag_ids][]" class="tag_ids">
+                  </button>`
+    $('.js-selected_tags').append(html)
+  }
+
+  // タグのインクリメンタルサーチ
+  $('.js-tag_name_field').on('input', function(){
+    const keyword = this.value;
+    if (keyword === '') {
+      $('.js-tag_list').empty()
+      return
+    }
+    let tag_ids = []
+    if($('.tag_ids')) {
+      $('.tag_ids').each(function(_, ele){
+        tag_ids.push(ele.value)
+      })
+    }
+    $.ajax({
+      url: '/api/tags/search',
+      type: 'GET',
+      data: {
+        keyword: keyword,
+        tag_ids: tag_ids
+      },
+      dataType: 'json'
+    })
+    .done(function(tags) {
+      $('.js-tag_list').empty()
+      let tag_list_items = ''
+      tags.forEach(tag => {
+        tag_list_items += buildTag(tag)
+      });
+      $('.js-tag_list').append(tag_list_items)
+    })
+  })
+
+  // 追加ボタン
+  $('.js-tag_list').on('click', '.js-add_tag_btn', function(e) {
+    e.preventDefault()
+    appendTag($(this).prev().text(), $(this).prev()[0].dataset.id)
+    $(this).parent().remove()
+  })
+
+  // 削除ボタン
+  $('.js-selected_tags').on('click', '.js-selected_tag', function(e) {
+    e.preventDefault()
+    $(this).remove()
+  })
+
+  // タグ作成ボタン
+  $('.js-create_tag').on('click', function(e) {
+    e.preventDefault()
+    const tagName = $('.js-tag_name_field').val()
+    $.ajax({
+      url: '/api/tags',
+      type: 'POST',
+      data: {
+        tag_name: tagName
+      },
+      dataType: 'json'
+    })
+    .done(function(tags) {
+    })
+  })
+})

--- a/app/assets/javascripts/breadcrumb.js
+++ b/app/assets/javascripts/breadcrumb.js
@@ -1,6 +1,5 @@
 $(document).on('turbolinks:load', function() {
   $('.nav-item').each(function(i,ele){
-    console.log(ele)
     ele.classList.remove('active')
   })
   if (location.pathname === '/begginer'){

--- a/app/assets/stylesheets/answer_comments.scss
+++ b/app/assets/stylesheets/answer_comments.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the answer_comments controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@
 @import "custom";
 @import "session";
 @import "favorite";
+@import "tags"

--- a/app/assets/stylesheets/article_comments.scss
+++ b/app/assets/stylesheets/article_comments.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the article_comments controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,0 +1,23 @@
+.tag_list {
+  max-width: 180px;
+  .list-group-item {
+    height: 2rem;
+    padding: 0.25rem 0.75rem;
+  }
+}
+
+.tag_list {
+  .add_tag_btn {
+    padding: 0 0.5rem;
+  }
+}
+
+.pd0 {
+  padding: 0 !important;
+}
+
+.selected-tag {
+  margin-bottom: 5px;
+  padding-right: 0.4rem;
+  padding-left: 0.4rem;
+}

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,8 +1,8 @@
 .tag_list {
-  max-width: 180px;
   .list-group-item {
     height: 2rem;
     padding: 0.25rem 0.75rem;
+    overflow: hidden;
   }
 }
 

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,0 +1,6 @@
+class Api::TagsController < ApplicationController
+  def search
+    @tags = Tag.where('name LIKE(?)', "#{params[:keyword]}%").where.not(id: params[:tag_ids])
+    render json: @tags
+  end
+end

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,6 +1,21 @@
 class Api::TagsController < ApplicationController
+
   def search
     @tags = Tag.where('name LIKE(?)', "#{params[:keyword]}%").where.not(id: params[:tag_ids])
     render json: @tags
+  end
+
+  def create
+    @tag = Tag.new(tag_params)
+    if @tag.save
+      render json: @tag
+    else
+      render json: @tag
+    end
+  end
+
+  private
+  def tag_params
+    params.permit(:name)
   end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,2 +1,0 @@
-module TagsHelper
-end

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -8,7 +8,8 @@
             = text_field_tag :tag, :name, value: "", placeholder: 'タグを検索', class: "form-control js-tag_name_field"
             %ul.list-group.tag_list.js-tag_list
           .col-4
-            = button_to 'タグを作成', "", class: 'btn btn-info js-create_tag'
+            %button{class: 'btn btn-info js-create_tag'}
+              タグを作成
       .col-6.card.pd0
         .card-header 選択中のタグ
         .card-body.js-selected_tags

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -1,9 +1,17 @@
 = form_with model: @article, local: true do |f|
   .form-group
     = f.label "タグを選ぶ(必須)", for: "exampletitle" ,class: "pr-3"
-    .alert.alert-secondary
-      = f.collection_check_boxes(:tag_ids, Tag.all, :id, :name, {}, required: true)
-      =link_to "タグを登録する", new_tag_path ,class: "pl-3"
+    .form-row
+      .form-group.col-6.container
+        .row
+          .col-8
+            = text_field_tag :tag, :name, value: "", placeholder: 'タグを検索', class: "form-control js-tag_name_field"
+            %ul.list-group.tag_list.js-tag_list
+          .col-4
+            = button_to 'タグを作成', "", class: 'btn btn-info js-create_tag'
+      .col-6.card.pd0
+        .card-header 選択中のタグ
+        .card-body.js-selected_tags
     = f.label "タイトル", for: "exampletitle"
     = f.text_field :title, id: "exampletitle", class: "form-control", rows: "1", required: true
     %br

--- a/app/views/questions/_form.html.haml
+++ b/app/views/questions/_form.html.haml
@@ -3,13 +3,22 @@
   .col-md-8
     = form_with model: @question, local: true do |f|
       .form-group
-        = f.label "タグを選ぶ(任意)", for: "exampletitle" ,class: "pr-3"
-        .alert.alert-secondary
-          = f.collection_check_boxes(:tag_ids, Tag.all, :id, :name)
-          =link_to "タグを登録する", new_tag_path ,class: "pl-3"
-        = f.label "タイトル", for: "exampletitle"
-        = f.text_field :title, id: "exampletitle", class: "form-control", rows: "1"
-        %br
-          = f.label "質問内容", for: "examplecontent"
-          = f.text_area :content, id: "examplecontent", class: "form-control",placeholder: "```コードブロックが使えます```", rows: "10"
-        = f.submit "質問を投稿する", class: "btn btn-outline-warning btn-block mt-2"
+        = f.label "タグを選ぶ(必須)", for: "exampletitle" ,class: "pr-3"
+        .form-row
+          .form-group.col-6.container
+            .row
+              .col-8
+                = text_field_tag :tag, :name, value: "", placeholder: 'タグを検索', class: "form-control js-tag_name_field"
+                %ul.list-group.tag_list.js-tag_list
+              .col-4
+                %button{class: 'btn btn-info js-create_tag'}
+                  タグを作成
+          .col-6.card.pd0
+            .card-header 選択中のタグ
+            .card-body.js-selected_tags
+      = f.label "タイトル", for: "exampletitle"
+      = f.text_field :title, id: "exampletitle", class: "form-control", rows: "1"
+      %br
+        = f.label "質問内容", for: "examplecontent"
+        = f.text_area :content, id: "examplecontent", class: "form-control",placeholder: "```コードブロックが使えます```", rows: "10"
+      = f.submit "質問を投稿する", class: "btn btn-outline-warning btn-block mt-2"

--- a/app/views/questions/_form.html.haml
+++ b/app/views/questions/_form.html.haml
@@ -3,7 +3,7 @@
   .col-md-8
     = form_with model: @question, local: true do |f|
       .form-group
-        = f.label "タグを選ぶ(必須)", for: "exampletitle" ,class: "pr-3"
+        = f.label "タグを選ぶ(任意)", for: "exampletitle" ,class: "pr-3"
         .form-row
           .form-group.col-6.container
             .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,14 @@ Rails.application.routes.draw do
     get 'users_index'
   end
 
+  namespace :api, defaults: { format: :json } do
+    resources :tags, only: :create do
+      collection do
+        get 'search'
+      end
+    end
+  end
+
   resources :questions do
     resources :answers, only: [:create, :destroy] do
       resources :answer_comments, only: [:create, :destroy]


### PR DESCRIPTION
# What
- 記事＆質問投稿時に、タグをインクリメンタルサーチで探して選ぶ方式に変更した
  - タグの新規作成も同じ画面からできるようにした

# Why
- なぜこの変更をするのか
  - タグが増えてきた時にチェックボックスで目的のタグを探すのは難しいため
  - 目的のタグが無い場合、作成するためにページ遷移を挟むのはUXが悪いため
- 何が問題となっているのか
- ユーザの操作をどう改善したいのか

# 影響範囲
- ユーザへの影響(メリット・デメリット)
- 開発側への影響(メリット・デメリット)
- その他コードへの影響

# 関連URL
- 参考URL
- 画像URL
![ts_tags](https://user-images.githubusercontent.com/43090220/78637995-79d47780-78e6-11ea-9d79-f5109587a83a.gif)


# 大きな仕様変更
- before
- after

# 使い方、確認の仕方、テストの仕方
- 使い方の説明
- 再現手順等 

# 注意事項
- 注意

# テスト結果とテスト項目
## テストコード実装済み
- [x] テストする際の項目を、このように、チェック可能な形式で記載する。

## 目視確認
- [ ] テストする際の項目を、このように、チェック可能な形式で記載する。

# TODOと保留
- TODO
- 保留項目
  - タグの一覧・新規作成ページは不要になったが削除していない
  - 初めての方への案内に齟齬が出ている

# その他
